### PR TITLE
refactor: refactor areaBrand component

### DIFF
--- a/src/layouts/areaBrand.tsx
+++ b/src/layouts/areaBrand.tsx
@@ -1,37 +1,46 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 
 type AreaBrandProps = {
   area: string
 };
 
 export default function AreaBrand({ area = 'TAIWAN' }: AreaBrandProps) {
+  const patternHeight = area.length * 166;
+
   return (
     <Box
       position={{ xs: 'fixed', md: 'relative' }}
-      display="flex"
-      flexShrink={0}
-      alignItems="baseline"
+      width="146px"
       height="100%"
-      overflow="hidden"
       sx={{
-        backgroundImage:
-              'linear-gradient(to bottom, #e60000, #ffcc00, #007f00, #0000cc)',
-        backgroundClip: 'text',
-        color: 'transparent',
         opacity: { xs: 0.1, md: 1 },
       }}
     >
-      <Typography
-        fontSize="200px"
-        lineHeight="73.5%"
-        letterSpacing="23px"
-        marginBottom="-50px"
-        sx={{ writingMode: 'vertical-lr' }}
-        fontWeight={700}
-      >
-        {area}
-      </Typography>
+      <svg width="100%" height="100%">
+        <defs>
+          <linearGradient id="rainbow" x1="0" x2="100%" y1="0" y2="0">
+            <stop stopColor="#e60000" offset="0%" />
+            <stop stopColor="#ffcc00" offset="33.33%" />
+            <stop stopColor="#007f00" offset="66.66%" />
+            <stop stopColor="#0000cc" offset="100%" />
+          </linearGradient>
+          <pattern id="Text" width="100%" height={patternHeight} patternUnits="userSpaceOnUse">
+            <text
+              x="-70"
+              y="70"
+              fontSize="200px"
+              fill="url(#rainbow)"
+              transform="rotate(90 0 70)"
+              fontWeight={700}
+              letterSpacing="23px"
+            >
+              {area}
+            </text>
+          </pattern>
+        </defs>
+        <rect fill="url(#Text)" width="100%" height="100%" />
+      </svg>
     </Box>
   );
 }


### PR DESCRIPTION
# Summary

- Change component from css background logic to svg background with text.
- Solve the problem that the text is too short to be placed at the bottom under high-resolution screens.

# Some Demo 

- Before
![image](https://user-images.githubusercontent.com/46883007/229453712-975847b6-ab4c-44d4-972e-6302c04f80a4.png)

- After
![image](https://user-images.githubusercontent.com/46883007/229453776-cbe30a9b-1f37-458b-9f2c-2d523eb5a6e7.png)

